### PR TITLE
fix template example metadata typo

### DIFF
--- a/templates/examples/lemma-overloading/README.md
+++ b/templates/examples/lemma-overloading/README.md
@@ -39,7 +39,7 @@ typeclasses-based re-implementation for comparison.
   - Derek Dreyer
 - Coq-community maintainer(s):
   - [Anton Trunov](https://github.com/anton-trunov) (**@anton-trunov**)
-- License: [Overloaded lemmas](LICENSE.md)
+- License: [GNU General Public License v3](LICENSE.md)
 - Compatible Coq versions: Coq 8.8 or greater
 - Additional dependencies:
   - Mathcomp 1.6.2 or greater (mathcomp/ssreflect package suffices)

--- a/templates/examples/lemma-overloading/meta.yml
+++ b/templates/examples/lemma-overloading/meta.yml
@@ -28,7 +28,7 @@ maintainers:
 opam-file-maintainer: palmskog@gmail.com
 
 license:
-  fullame: GNU General Public License v3
+  fullname: GNU General Public License v3
   shortname: GPL3
   file: LICENSE.md
 


### PR DESCRIPTION
I'm going to use this small PR to outline for some additional thoughts on the mustache templates.

First, I think it's too restrictive to assume in the template that all projects have a `theories` directory. This is not true, for example, for [corn](https://github.com/coq-community/corn). I tend to only use the `theories` convention for plugin projects.

Second, since most projects will want to fill in more documentation in `README.md`, why not just have a final template row:
```
{{ documentation }}
```
instead of
```
{{! Optional additional sections }}
```
As far as I understand the mustache spec, undefined variables will simply not be rendered. I think it makes sense to keep everything in `meta.yml` (in a project's root directory) rather than relying on an additional file to generate the full `README.md`.

@Zimmi48 do you agree?