### PR TITLE
allow both initial and other authors in README.md and opam templates

### DIFF
--- a/templates/README.md.mustache
+++ b/templates/README.md.mustache
@@ -21,9 +21,9 @@
 
 ## Meta
 
-- Initial author(s):
+- Author(s):
 {{# authors }}
-  - {{ name }}
+  - {{ name }}{{# initial }} (initial){{/ initial }}
 {{/ authors }}
 - Coq-community maintainer(s):
 {{# maintainers }}

--- a/templates/examples/aac-tactics/README.md
+++ b/templates/examples/aac-tactics/README.md
@@ -31,9 +31,10 @@ The implementation and underlying theory is decribed in the paper
 
 ## Meta
 
-- Initial author(s):
-  - Thomas Braibant
-  - Damien Pous
+- Author(s):
+  - Thomas Braibant (initial)
+  - Damien Pous (initial)
+  - Fabian Kunze
 - Coq-community maintainer(s):
   - Fabian Kunze ([**@fakusb**](https://github.com/fakusb))
   - Karl Palmskog ([**@palmskog**](https://github.com/palmskog))

--- a/templates/examples/aac-tactics/meta.yml
+++ b/templates/examples/aac-tactics/meta.yml
@@ -16,7 +16,11 @@ description: |
 
 authors:
 - name: Thomas Braibant
+  initial: true
 - name: Damien Pous
+  initial: true
+- name: Fabian Kunze
+  initial: false
 
 maintainers:
 - name: Fabian Kunze

--- a/templates/examples/aac-tactics/opam
+++ b/templates/examples/aac-tactics/opam
@@ -25,4 +25,5 @@ tags: [
 authors: [
   "Thomas Braibant"
   "Damien Pous"
+  "Fabian Kunze"
 ]

--- a/templates/examples/lemma-overloading/README.md
+++ b/templates/examples/lemma-overloading/README.md
@@ -34,11 +34,11 @@ re-implementations for comparison.
 
 ## Meta
 
-- Initial author(s):
-  - Georges Gonthier
-  - Beta Ziliani
-  - Aleksandar Nanevski
-  - Derek Dreyer
+- Author(s):
+  - Georges Gonthier (initial)
+  - Beta Ziliani (initial)
+  - Aleksandar Nanevski (initial)
+  - Derek Dreyer (initial)
 - Coq-community maintainer(s):
   - Anton Trunov ([**@anton-trunov**](https://github.com/anton-trunov))
   - Karl Palmskog ([**@palmskog**](https://github.com/palmskog))

--- a/templates/examples/lemma-overloading/meta.yml
+++ b/templates/examples/lemma-overloading/meta.yml
@@ -19,9 +19,13 @@ description: |
 
 authors:
 - name: Georges Gonthier
+  initial: true
 - name: Beta Ziliani
+  initial: true
 - name: Aleksandar Nanevski
+  initial: true
 - name: Derek Dreyer
+  initial: true
 
 maintainers:
 - name: Anton Trunov


### PR DESCRIPTION
Here is my proposal for modifying templates to allow non-initial authors to be credited in `README.md` and `opam`.

Fixes #29.