### PR TITLE
allow multiple categories in mustache opam template, update examples

### DIFF
--- a/templates/examples/aac-tactics/README.md
+++ b/templates/examples/aac-tactics/README.md
@@ -67,5 +67,50 @@ the `AAC_tactics` namespace.
 
 ## Documentation
 
-The file `Tutorial.v` provides a succinct introduction and more examples of how to use this plugin.
+After installation, definitions and tactics can be found under the `AAC_tactics` namespace.
+
+The following example shows an application of the tactics for reasoning over Z binary numbers:
+```coq
+Require Import AAC_tactics.AAC.
+Require AAC_tactics.Instances.
+Require Import ZArith.
+
+Section ZOpp.
+  Import Instances.Z.
+  Variables a b c : Z.
+  Hypothesis H: forall x, x + Z.opp x = 0.
+
+  Goal a + b + c + Z.opp (c + a) = b.
+    aac_rewrite H.
+    aac_reflexivity.
+  Qed.
+End ZOpp.
+```
+
+The file [Tutorial.v](theories/Tutorial.v) provides a succinct introduction
+and more examples of how to use this plugin.
+
+The file [Instances.v](theories/Instances.v) defines several type class instances
+for frequent use-cases of this plugin, that should allow you to use it off-the-shelf.
+Namely, it contains instances for:
+
+- Peano naturals	(`Import Instances.Peano.`)
+- Z binary numbers	(`Import Instances.Z.`)
+- N binary numbers	(`Import Instances.N.`)
+- P binary numbers	(`Import Instances.P.`)
+- Rational numbers	(`Import Instances.Q.`)
+- Prop			(`Import Instances.Prop_ops.`)
+- Booleans		(`Import Instances.Bool.`)
+- Relations		(`Import Instances.Relations.`)
+- all of the above	(`Import Instances.All.`)
+
+To understand the inner workings of the tactics, please refer to
+the `.mli` files as the main source of information on each `.ml` file.
+
+## Acknowledgements
+
+The initial authors are grateful to Evelyne Contejean, Hugo Herbelin,
+Assia Mahboubi, and Matthieu Sozeau for highly instructive discussions.
+The plugin took inspiration from the plugin tutorial "constructors" by
+Matthieu Sozeau, distributed under the LGPL 2.1.
 

--- a/templates/examples/aac-tactics/README.md
+++ b/templates/examples/aac-tactics/README.md
@@ -67,8 +67,6 @@ the `AAC_tactics` namespace.
 
 ## Documentation
 
-After installation, definitions and tactics can be found under the `AAC_tactics` namespace.
-
 The following example shows an application of the tactics for reasoning over Z binary numbers:
 ```coq
 Require Import AAC_tactics.AAC.

--- a/templates/examples/aac-tactics/meta.yml
+++ b/templates/examples/aac-tactics/meta.yml
@@ -61,8 +61,6 @@ categories:
 documentation: |
   ## Documentation
 
-  After installation, definitions and tactics can be found under the `AAC_tactics` namespace.
-  
   The following example shows an application of the tactics for reasoning over Z binary numbers:
   ```coq
   Require Import AAC_tactics.AAC.

--- a/templates/examples/aac-tactics/meta.yml
+++ b/templates/examples/aac-tactics/meta.yml
@@ -54,10 +54,57 @@ keywords:
 - name: rewriting modulo ac
 - name: decision procedure
 
-category: Miscellaneous/Coq Extensions
+categories:
+- name: Miscellaneous/Coq Extensions
+- name: Computer Science/Decision Procedures and Certified Algorithms/Decision procedures
 
 documentation: |
   ## Documentation
 
-  The file `Tutorial.v` provides a succinct introduction and more examples of how to use this plugin.
+  After installation, definitions and tactics can be found under the `AAC_tactics` namespace.
+  
+  The following example shows an application of the tactics for reasoning over Z binary numbers:
+  ```coq
+  Require Import AAC_tactics.AAC.
+  Require AAC_tactics.Instances.
+  Require Import ZArith.
+  
+  Section ZOpp.
+    Import Instances.Z.
+    Variables a b c : Z.
+    Hypothesis H: forall x, x + Z.opp x = 0.
+  
+    Goal a + b + c + Z.opp (c + a) = b.
+      aac_rewrite H.
+      aac_reflexivity.
+    Qed.
+  End ZOpp.
+  ```
+  
+  The file [Tutorial.v](theories/Tutorial.v) provides a succinct introduction
+  and more examples of how to use this plugin.
+  
+  The file [Instances.v](theories/Instances.v) defines several type class instances
+  for frequent use-cases of this plugin, that should allow you to use it off-the-shelf.
+  Namely, it contains instances for:
+  
+  - Peano naturals	(`Import Instances.Peano.`)
+  - Z binary numbers	(`Import Instances.Z.`)
+  - N binary numbers	(`Import Instances.N.`)
+  - P binary numbers	(`Import Instances.P.`)
+  - Rational numbers	(`Import Instances.Q.`)
+  - Prop			(`Import Instances.Prop_ops.`)
+  - Booleans		(`Import Instances.Bool.`)
+  - Relations		(`Import Instances.Relations.`)
+  - all of the above	(`Import Instances.All.`)
+  
+  To understand the inner workings of the tactics, please refer to
+  the `.mli` files as the main source of information on each `.ml` file.
+  
+  ## Acknowledgements
+  
+  The initial authors are grateful to Evelyne Contejean, Hugo Herbelin,
+  Assia Mahboubi, and Matthieu Sozeau for highly instructive discussions.
+  The plugin took inspiration from the plugin tutorial "constructors" by
+  Matthieu Sozeau, distributed under the LGPL 2.1.
 ---

--- a/templates/examples/aac-tactics/opam
+++ b/templates/examples/aac-tactics/opam
@@ -20,6 +20,7 @@ tags: [
   "keyword:rewriting modulo ac"
   "keyword:decision procedure"
   "category:Miscellaneous/Coq Extensions"
+  "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures"
   "logpath:AAC_tactics"
 ]
 authors: [

--- a/templates/examples/lemma-overloading/meta.yml
+++ b/templates/examples/lemma-overloading/meta.yml
@@ -66,7 +66,8 @@ keywords:
 - name: hoare type theory
 - name: lemma overloading
 
-category: Computer Science/Data Types and Data Structures
+categories:
+- name: Computer Science/Data Types and Data Structures
 
 documentation: |
   ## Files described in the paper

--- a/templates/opam.mustache
+++ b/templates/opam.mustache
@@ -24,7 +24,9 @@ tags: [
 {{# keywords }}
   "keyword:{{ name }}"
 {{/ keywords }}
-  "category:{{ category }}"
+{{# categories }}
+  "category:{{ name }}"
+{{/ categories }}
   "logpath:{{ namespace }}"
 ]
 authors: [


### PR DESCRIPTION
Many packages in Coq's OPAM repo actually have several categories in their `opam` files. For example, the most recent version of `coq-color` has seven categories. Here are changes to support this in our templates.