### PR TITLE
Update examples generated from templates

### DIFF
--- a/templates/examples/aac-tactics/meta.yml
+++ b/templates/examples/aac-tactics/meta.yml
@@ -32,7 +32,7 @@ opam-file-maintainer: palmskog@gmail.com
 
 license:
   fullname: GNU Lesser General Public License v3
-  shortname: LGPL3
+  shortname: LGPL 3
 
 plugin: true
 

--- a/templates/examples/aac-tactics/opam
+++ b/templates/examples/aac-tactics/opam
@@ -4,7 +4,7 @@ maintainer: "palmskog@gmail.com"
 homepage: "https://github.com/coq-community/aac-tactics"
 dev-repo: "https://github.com/coq-community/aac-tactics.git"
 bug-reports: "https://github.com/coq-community/aac-tactics/issues"
-license: "LGPL3"
+license: "LGPL 3"
 
 build: [make "-j%{jobs}%"]
 install: [make "install"]

--- a/templates/examples/lemma-overloading/README.md
+++ b/templates/examples/lemma-overloading/README.md
@@ -43,9 +43,10 @@ re-implementations for comparison.
   - Anton Trunov ([**@anton-trunov**](https://github.com/anton-trunov))
   - Karl Palmskog ([**@palmskog**](https://github.com/palmskog))
 - License: [GNU General Public License v3](LICENSE.md)
-- Compatible Coq versions: Coq 8.8 or greater
+- Compatible Coq versions: Coq 8.8 or greater (use releases for other Coq versions)
 - Additional dependencies:
-  - MathComp 1.7.0 or greater (`ssreflect` suffices)
+  - [MathComp](https://math-comp.github.io/math-comp/) 1.7.0 or greater (`ssreflect` suffices)
+
 
 
 ## Building and installation instructions
@@ -125,7 +126,7 @@ These files contains the same automated lemmas as in the files `indom`, `cancel`
 
 ## Note
 
-The files not mentioned in this README file are part of the HTT library,
+The files not mentioned here are part of the HTT library,
 from [Structuring the Verification of Heap-Manipulating Programs][reflect]
 by A. Nanevski et al., POPL'10.
 

--- a/templates/examples/lemma-overloading/meta.yml
+++ b/templates/examples/lemma-overloading/meta.yml
@@ -37,11 +37,11 @@ opam-file-maintainer: palmskog@gmail.com
 
 license:
   fullname: GNU General Public License v3
-  shortname: GPL3
+  shortname: GPL 3
   file: LICENSE.md
 
 supported_coq_versions:
-  text: Coq 8.8 or greater
+  text: Coq 8.8 or greater (use releases for other Coq versions)
   opam: '{(>= "8.8" & < "8.10~") | (= "dev")}'
 
 tested_coq_versions:
@@ -56,7 +56,8 @@ dependencies:
     name: coq-mathcomp-ssreflect
     version: '{(>= "1.7.0" & < "1.8~") | (= "dev")}'
   nix: ssreflect
-  description: MathComp 1.7.0 or greater (`ssreflect` suffices)
+  description: |
+    [MathComp](https://math-comp.github.io/math-comp/) 1.7.0 or greater (`ssreflect` suffices)
 
 namespace: LemmaOverloading
 
@@ -125,7 +126,7 @@ documentation: |
   
   ## Note
   
-  The files not mentioned in this README file are part of the HTT library,
+  The files not mentioned here are part of the HTT library,
   from [Structuring the Verification of Heap-Manipulating Programs][reflect]
   by A. Nanevski et al., POPL'10.
 

--- a/templates/examples/lemma-overloading/opam
+++ b/templates/examples/lemma-overloading/opam
@@ -4,7 +4,7 @@ maintainer: "palmskog@gmail.com"
 homepage: "https://github.com/coq-community/lemma-overloading"
 dev-repo: "https://github.com/coq-community/lemma-overloading.git"
 bug-reports: "https://github.com/coq-community/lemma-overloading/issues"
-license: "GPL3"
+license: "GPL 3"
 
 build: [make "-j%{jobs}%"]
 install: [make "install"]


### PR DESCRIPTION
I updated the `meta.yml` files a bit for the examples. In particular, I noticed that the preferred form for licenses in OPAM files in the Coq OPAM repo includes a space between the acronym and the version (`LGPL 2.1` vs. `LGPL2.1`). I don't think we should override this convention.