### PR TITLE
add optional date to opam template

### DIFF
--- a/templates/opam.mustache
+++ b/templates/opam.mustache
@@ -27,6 +27,9 @@ tags: [
 {{# categories }}
   "category:{{ name }}"
 {{/ categories }}
+{{# date }}
+  "date:{{ date }}"
+{{/ date }}
   "logpath:{{ namespace }}"
 ]
 authors: [


### PR DESCRIPTION
According to the Coq OPAM archive spec, released packages should include a `date` attribute under the `tags` field to indicate when the release was made, e.g., `"date:2018-07-24"`. To introduce more automation, `meta.yml` can include a `date` variable that automatically introduces this into the `opam` file.