### PR TITLE
add support for paper metadata in templates

### DIFF
--- a/templates/README.md.mustache
+++ b/templates/README.md.mustache
@@ -4,6 +4,12 @@
 [![Contributing][contributing-shield]][contributing-link]
 [![Code of Conduct][conduct-shield]][conduct-link]
 [![Gitter][gitter-shield]][gitter-link]
+{{# paper }}
+[![DOI][doi-shield]][doi-link]
+
+[doi-shield]: https://zenodo.org/badge/DOI/{{ doi }}.svg
+[doi-link]: https://doi.org/{{ doi }}
+{{/ paper }}
 
 [travis-shield]: https://travis-ci.com/coq-community/{{ shortname }}.svg?branch=master
 [travis-link]: https://travis-ci.com/coq-community/{{ shortname }}/builds
@@ -18,6 +24,11 @@
 [gitter-link]: https://gitter.im/coq-community/Lobby
 
 {{& description }}
+
+{{# paper }}
+More details about the project can be found in the paper
+[{{ title }}]({{ url }}).
+{{/ paper }}
 
 ## Meta
 

--- a/templates/examples/aac-tactics/README.md
+++ b/templates/examples/aac-tactics/README.md
@@ -4,6 +4,10 @@
 [![Contributing][contributing-shield]][contributing-link]
 [![Code of Conduct][conduct-shield]][conduct-link]
 [![Gitter][gitter-shield]][gitter-link]
+[![DOI][doi-shield]][doi-link]
+
+[doi-shield]: https://zenodo.org/badge/DOI/10.1007/978-3-642-25379-9_14.svg
+[doi-link]: https://doi.org/10.1007/978-3-642-25379-9_14
 
 [travis-shield]: https://travis-ci.com/coq-community/aac-tactics.svg?branch=master
 [travis-link]: https://travis-ci.com/coq-community/aac-tactics/builds
@@ -19,15 +23,14 @@
 
 This Coq plugin provides tactics for rewriting universally quantified
 equations, modulo associativity and commutativity of some operator.
-
 The tactics can be applied for custom operators by registering the
 operators and their properties as type class instances. Many common
 operator instances, such as for Z binary arithmetic and booleans, are
 provided with the plugin.
 
-The implementation and underlying theory is decribed in the paper
-[Tactics for Reasoning modulo AC in Coq](https://arxiv.org/abs/1106.4448).
 
+More details about the project can be found in the paper
+[Tactics for Reasoning modulo AC in Coq](https://arxiv.org/abs/1106.4448).
 
 ## Meta
 
@@ -38,7 +41,7 @@ The implementation and underlying theory is decribed in the paper
 - Coq-community maintainer(s):
   - Fabian Kunze ([**@fakusb**](https://github.com/fakusb))
   - Karl Palmskog ([**@palmskog**](https://github.com/palmskog))
-- License: [GNU Lesser General Public License v3](LICENSE)
+- License: [GNU Lesser General Public License v3.0 or later](LICENSE)
 - Compatible Coq versions: Coq master (use the corresponding branch or release for other Coq versions)
 - Compatible OCaml versions: all versions supported by Coq
 - Additional dependencies: none

--- a/templates/examples/aac-tactics/meta.yml
+++ b/templates/examples/aac-tactics/meta.yml
@@ -5,14 +5,15 @@ shortname: aac-tactics
 description: |
   This Coq plugin provides tactics for rewriting universally quantified
   equations, modulo associativity and commutativity of some operator.
-
   The tactics can be applied for custom operators by registering the
   operators and their properties as type class instances. Many common
   operator instances, such as for Z binary arithmetic and booleans, are
   provided with the plugin.
 
-  The implementation and underlying theory is decribed in the paper
-  [Tactics for Reasoning modulo AC in Coq](https://arxiv.org/abs/1106.4448).
+paper:
+  doi: 10.1007/978-3-642-25379-9_14
+  url: https://arxiv.org/abs/1106.4448
+  title: Tactics for Reasoning modulo AC in Coq
 
 authors:
 - name: Thomas Braibant
@@ -31,7 +32,8 @@ maintainers:
 opam-file-maintainer: palmskog@gmail.com
 
 license:
-  fullname: GNU Lesser General Public License v3
+  fullname: GNU Lesser General Public License v3.0 or later
+  identifier: LGPL-3.0-or-later
   shortname: LGPL 3
 
 plugin: true

--- a/templates/examples/lemma-overloading/README.md
+++ b/templates/examples/lemma-overloading/README.md
@@ -4,6 +4,10 @@
 [![Contributing][contributing-shield]][contributing-link]
 [![Code of Conduct][conduct-shield]][conduct-link]
 [![Gitter][gitter-shield]][gitter-link]
+[![DOI][doi-shield]][doi-link]
+
+[doi-shield]: https://zenodo.org/badge/DOI/10.1017/S0956796813000051.svg
+[doi-link]: https://doi.org/10.1017/S0956796813000051
 
 [travis-shield]: https://travis-ci.com/coq-community/lemma-overloading.svg?branch=master
 [travis-link]: https://travis-ci.com/coq-community/lemma-overloading/builds
@@ -17,10 +21,8 @@
 [gitter-shield]: https://img.shields.io/badge/chat-on%20gitter-%23c1272d.svg
 [gitter-link]: https://gitter.im/coq-community/Lobby
 
-This project contains Hoare Type Theory libraries presented
-in the paper [How to make ad hoc proof automation less ad hoc][paper].
-
-The project demonstrates a series of design patterns for programming
+This project contains Hoare Type Theory libraries which
+demonstrate a series of design patterns for programming
 with [canonical structures][manual] that enable one to carefully
 and predictably coax Coq's type inference engine into triggering
 the execution of user-supplied algorithms during unification, and
@@ -28,9 +30,11 @@ illustrates these patterns through several realistic examples drawn
 from Hoare Type Theory. The project also contains typeclass-based
 re-implementations for comparison.
 
-[paper]: https://software.imdea.org/~aleks/papers/lessadhoc/journal.pdf
 [manual]: https://coq.inria.fr/distrib/current/refman/addendum/canonical-structures.html
 
+
+More details about the project can be found in the paper
+[How to make ad hoc proof automation less ad hoc](https://software.imdea.org/~aleks/papers/lessadhoc/journal.pdf).
 
 ## Meta
 
@@ -42,10 +46,10 @@ re-implementations for comparison.
 - Coq-community maintainer(s):
   - Anton Trunov ([**@anton-trunov**](https://github.com/anton-trunov))
   - Karl Palmskog ([**@palmskog**](https://github.com/palmskog))
-- License: [GNU General Public License v3](LICENSE.md)
-- Compatible Coq versions: Coq 8.8 or greater (use releases for other Coq versions)
+- License: [GNU General Public License v3.0 or later](LICENSE.md)
+- Compatible Coq versions: Coq 8.8 or later (use releases for other Coq versions)
 - Additional dependencies:
-  - [MathComp](https://math-comp.github.io/math-comp/) 1.7.0 or greater (`ssreflect` suffices)
+  - [MathComp](https://math-comp.github.io/math-comp/) 1.7.0 or later (`ssreflect` suffices)
 
 
 

--- a/templates/examples/lemma-overloading/meta.yml
+++ b/templates/examples/lemma-overloading/meta.yml
@@ -3,10 +3,8 @@ fullname: Lemma overloading
 shortname: lemma-overloading
 
 description: |
-  This project contains Hoare Type Theory libraries presented
-  in the paper [How to make ad hoc proof automation less ad hoc][paper].
-
-  The project demonstrates a series of design patterns for programming
+  This project contains Hoare Type Theory libraries which
+  demonstrate a series of design patterns for programming
   with [canonical structures][manual] that enable one to carefully
   and predictably coax Coq's type inference engine into triggering
   the execution of user-supplied algorithms during unification, and
@@ -14,8 +12,12 @@ description: |
   from Hoare Type Theory. The project also contains typeclass-based
   re-implementations for comparison.
 
-  [paper]: https://software.imdea.org/~aleks/papers/lessadhoc/journal.pdf
   [manual]: https://coq.inria.fr/distrib/current/refman/addendum/canonical-structures.html
+
+paper:
+  doi: 10.1017/S0956796813000051
+  url: https://software.imdea.org/~aleks/papers/lessadhoc/journal.pdf
+  title: How to make ad hoc proof automation less ad hoc
 
 authors:
 - name: Georges Gonthier
@@ -36,12 +38,13 @@ maintainers:
 opam-file-maintainer: palmskog@gmail.com
 
 license:
-  fullname: GNU General Public License v3
+  fullname: GNU General Public License v3.0 or later
+  identifier: GPL-3.0-or-later
   shortname: GPL 3
   file: LICENSE.md
 
 supported_coq_versions:
-  text: Coq 8.8 or greater (use releases for other Coq versions)
+  text: Coq 8.8 or later (use releases for other Coq versions)
   opam: '{(>= "8.8" & < "8.10~") | (= "dev")}'
 
 tested_coq_versions:
@@ -57,7 +60,7 @@ dependencies:
     version: '{(>= "1.7.0" & < "1.8~") | (= "dev")}'
   nix: ssreflect
   description: |
-    [MathComp](https://math-comp.github.io/math-comp/) 1.7.0 or greater (`ssreflect` suffices)
+    [MathComp](https://math-comp.github.io/math-comp/) 1.7.0 or later (`ssreflect` suffices)
 
 namespace: LemmaOverloading
 


### PR DESCRIPTION
Lots of projects have at least one paper that describes them. For these projects, it makes sense to record metadata for both URL to access paper and DOI for paper (for citing). Here is optional support for having such a paper in the templates. Would make README maintenance easier.