### PR TITLE
use SPDX license identifier in template opam file

### DIFF
--- a/templates/examples/aac-tactics/meta.yml
+++ b/templates/examples/aac-tactics/meta.yml
@@ -34,7 +34,6 @@ opam-file-maintainer: palmskog@gmail.com
 license:
   fullname: GNU Lesser General Public License v3.0 or later
   identifier: LGPL-3.0-or-later
-  shortname: LGPL 3
 
 plugin: true
 

--- a/templates/examples/aac-tactics/opam
+++ b/templates/examples/aac-tactics/opam
@@ -4,7 +4,7 @@ maintainer: "palmskog@gmail.com"
 homepage: "https://github.com/coq-community/aac-tactics"
 dev-repo: "https://github.com/coq-community/aac-tactics.git"
 bug-reports: "https://github.com/coq-community/aac-tactics/issues"
-license: "LGPL 3"
+license: "LGPL-3.0-or-later"
 
 build: [make "-j%{jobs}%"]
 install: [make "install"]
@@ -14,13 +14,13 @@ depends: [
 ]
 
 tags: [
+  "category:Miscellaneous/Coq Extensions"
+  "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures"
   "keyword:reflexive tactic"
   "keyword:rewriting"
   "keyword:rewriting modulo associativity and commutativity"
   "keyword:rewriting modulo ac"
   "keyword:decision procedure"
-  "category:Miscellaneous/Coq Extensions"
-  "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures"
   "logpath:AAC_tactics"
 ]
 authors: [

--- a/templates/examples/lemma-overloading/meta.yml
+++ b/templates/examples/lemma-overloading/meta.yml
@@ -40,7 +40,6 @@ opam-file-maintainer: palmskog@gmail.com
 license:
   fullname: GNU General Public License v3.0 or later
   identifier: GPL-3.0-or-later
-  shortname: GPL 3
   file: LICENSE.md
 
 supported_coq_versions:

--- a/templates/examples/lemma-overloading/opam
+++ b/templates/examples/lemma-overloading/opam
@@ -4,7 +4,7 @@ maintainer: "palmskog@gmail.com"
 homepage: "https://github.com/coq-community/lemma-overloading"
 dev-repo: "https://github.com/coq-community/lemma-overloading.git"
 bug-reports: "https://github.com/coq-community/lemma-overloading/issues"
-license: "GPL 3"
+license: "GPL-3.0-or-later"
 
 build: [make "-j%{jobs}%"]
 install: [make "install"]
@@ -15,11 +15,11 @@ depends: [
 ]
 
 tags: [
+  "category:Computer Science/Data Types and Data Structures"
   "keyword:canonical structures"
   "keyword:proof automation"
   "keyword:hoare type theory"
   "keyword:lemma overloading"
-  "category:Computer Science/Data Types and Data Structures"
   "logpath:LemmaOverloading"
 ]
 authors: [

--- a/templates/opam.mustache
+++ b/templates/opam.mustache
@@ -4,7 +4,7 @@ maintainer: "{{& opam-file-maintainer }}{{^ opam-file-maintainer }}palmskog@gmai
 homepage: "https://github.com/coq-community/{{ shortname }}"
 dev-repo: "https://github.com/coq-community/{{ shortname }}.git"
 bug-reports: "https://github.com/coq-community/{{ shortname }}/issues"
-{{# license }}license: "{{ shortname }}"{{/ license }}
+{{# license }}license: "{{ identifier }}"{{/ license }}
 
 build: [make "-j%{jobs}%"]
 install: [make "install"]
@@ -21,12 +21,12 @@ depends: [
 ]
 
 tags: [
-{{# keywords }}
-  "keyword:{{ name }}"
-{{/ keywords }}
 {{# categories }}
   "category:{{ name }}"
 {{/ categories }}
+{{# keywords }}
+  "keyword:{{ name }}"
+{{/ keywords }}
 {{# date }}
   "date:{{ date }}"
 {{/ date }}


### PR DESCRIPTION
Also, get rid of informal license string and move tags for category up top for easier reading.