### PR TITLE
paper titles shouldn't be escaped in README.md template

### DIFF
--- a/templates/README.md.mustache
+++ b/templates/README.md.mustache
@@ -27,7 +27,7 @@
 
 {{# paper }}
 More details about the project can be found in the paper
-[{{ title }}]({{ url }}).
+[{{& title }}]({{ url }}).
 {{/ paper }}
 
 ## Meta


### PR DESCRIPTION
Micro fix.