### PR TITLE
generalize templates to also fit coq-contrib, introduce opam2 template

### DIFF
--- a/templates/README.md.mustache
+++ b/templates/README.md.mustache
@@ -11,8 +11,8 @@
 [doi-link]: https://doi.org/{{ doi }}
 {{/ paper }}
 
-[travis-shield]: https://travis-ci.com/coq-community/{{ shortname }}.svg?branch=master
-[travis-link]: https://travis-ci.com/coq-community/{{ shortname }}/builds
+[travis-shield]: https://travis-ci.com/{{ organization }}/{{ shortname }}.svg?branch=master
+[travis-link]: https://travis-ci.com/{{ organization }}/{{ shortname }}/builds
 
 [contributing-shield]: https://img.shields.io/badge/contributions-welcome-%23f7931e.svg
 [contributing-link]: https://github.com/coq-community/manifesto/blob/master/CONTRIBUTING.md
@@ -36,7 +36,7 @@ More details about the project can be found in the paper
 {{# authors }}
   - {{ name }}{{# initial }} (initial){{/ initial }}
 {{/ authors }}
-- Coq-community maintainer(s):
+- Maintainer(s):
 {{# maintainers }}
   - {{ name }} ([**@{{ nickname }}**](https://github.com/{{ nickname }}))
 {{/ maintainers }}
@@ -66,7 +66,7 @@ opam install coq-{{ shortname }}
 To instead build and install manually, do:
 
 ``` shell
-git clone https://github.com/coq-community/{{ shortname }}
+git clone https://github.com/{{ organization }}/{{ shortname }}
 cd {{ shortname }}
 make   # or make -j <number-of-cores-on-your-machine>
 make install

--- a/templates/examples/aac-tactics/.travis.yml
+++ b/templates/examples/aac-tactics/.travis.yml
@@ -1,7 +1,7 @@
 language: nix
 
 script:
-- nix-build --argstr coq-version-or-url "$COQ" --extra-substituters https://coq.cachix.org --trusted-public-keys "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= coq.cachix.org-1:Jgt0DwGAUo+wpxCM52k2V+E0hLoOzFPzvg94F65agtI="
+- nix-build --argstr coq-version-or-url "$COQ" --extra-substituters https://coq.cachix.org --trusted-public-keys "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= coq.cachix.org-1:5QW/wwEnD+l2jvN6QRbRRsa4hBHG3QiQQ26cxu1F5tI="
 
 matrix:
   include:

--- a/templates/examples/aac-tactics/README.md
+++ b/templates/examples/aac-tactics/README.md
@@ -38,7 +38,7 @@ More details about the project can be found in the paper
   - Thomas Braibant (initial)
   - Damien Pous (initial)
   - Fabian Kunze
-- Coq-community maintainer(s):
+- Maintainer(s):
   - Fabian Kunze ([**@fakusb**](https://github.com/fakusb))
   - Karl Palmskog ([**@palmskog**](https://github.com/palmskog))
 - License: [GNU Lesser General Public License v3.0 or later](LICENSE)

--- a/templates/examples/aac-tactics/meta.yml
+++ b/templates/examples/aac-tactics/meta.yml
@@ -1,6 +1,9 @@
 ---
 fullname: AAC tactics
 shortname: aac-tactics
+organization: coq-community
+
+synopsis: This Coq plugin provides tactics for rewriting universally quantified equations, modulo associative (and possibly commutative) operators
 
 description: |
   This Coq plugin provides tactics for rewriting universally quantified

--- a/templates/examples/aac-tactics/opam2
+++ b/templates/examples/aac-tactics/opam2
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/coq-community/aac-tactics"
+dev-repo: "https://github.com/coq-community/aac-tactics.git"
+bug-reports: "https://github.com/coq-community/aac-tactics/issues"
+license: "LGPL-3.0-or-later"
+
+synopsis: "This Coq plugin provides tactics for rewriting universally quantified equations, modulo associative (and possibly commutative) operators"
+description: """
+This Coq plugin provides tactics for rewriting universally quantified
+equations, modulo associativity and commutativity of some operator.
+The tactics can be applied for custom operators by registering the
+operators and their properties as type class instances. Many common
+operator instances, such as for Z binary arithmetic and booleans, are
+provided with the plugin.
+"""
+
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/AAC_tactics"]
+flags: light-uninstall
+depends: [
+  "ocaml"
+  "coq" {= "dev"}
+]
+
+tags: [
+  "category:Miscellaneous/Coq Extensions"
+  "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures"
+  "keyword:reflexive tactic"
+  "keyword:rewriting"
+  "keyword:rewriting modulo associativity and commutativity"
+  "keyword:rewriting modulo ac"
+  "keyword:decision procedure"
+  "logpath:AAC_tactics"
+]
+authors: [
+  "Thomas Braibant"
+  "Damien Pous"
+  "Fabian Kunze"
+]

--- a/templates/examples/lemma-overloading/.travis.yml
+++ b/templates/examples/lemma-overloading/.travis.yml
@@ -1,7 +1,7 @@
 language: nix
 
 script:
-- nix-build --argstr coq-version-or-url "$COQ" --extra-substituters https://coq.cachix.org --trusted-public-keys "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= coq.cachix.org-1:Jgt0DwGAUo+wpxCM52k2V+E0hLoOzFPzvg94F65agtI="
+- nix-build --argstr coq-version-or-url "$COQ" --extra-substituters https://coq.cachix.org --trusted-public-keys "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= coq.cachix.org-1:5QW/wwEnD+l2jvN6QRbRRsa4hBHG3QiQQ26cxu1F5tI="
 
 matrix:
   include:

--- a/templates/examples/lemma-overloading/README.md
+++ b/templates/examples/lemma-overloading/README.md
@@ -23,14 +23,12 @@
 
 This project contains Hoare Type Theory libraries which
 demonstrate a series of design patterns for programming
-with [canonical structures][manual] that enable one to carefully
+with canonical structures that enable one to carefully
 and predictably coax Coq's type inference engine into triggering
 the execution of user-supplied algorithms during unification, and
 illustrates these patterns through several realistic examples drawn
 from Hoare Type Theory. The project also contains typeclass-based
 re-implementations for comparison.
-
-[manual]: https://coq.inria.fr/distrib/current/refman/addendum/canonical-structures.html
 
 
 More details about the project can be found in the paper
@@ -43,7 +41,7 @@ More details about the project can be found in the paper
   - Beta Ziliani (initial)
   - Aleksandar Nanevski (initial)
   - Derek Dreyer (initial)
-- Coq-community maintainer(s):
+- Maintainer(s):
   - Anton Trunov ([**@anton-trunov**](https://github.com/anton-trunov))
   - Karl Palmskog ([**@palmskog**](https://github.com/palmskog))
 - License: [GNU General Public License v3.0 or later](LICENSE.md)

--- a/templates/examples/lemma-overloading/meta.yml
+++ b/templates/examples/lemma-overloading/meta.yml
@@ -1,18 +1,19 @@
 ---
 fullname: Lemma overloading
 shortname: lemma-overloading
+organization: coq-community
+
+synopsis: Libraries demonstrating design patterns for programming and proving with canonical structures in Coq
 
 description: |
   This project contains Hoare Type Theory libraries which
   demonstrate a series of design patterns for programming
-  with [canonical structures][manual] that enable one to carefully
+  with canonical structures that enable one to carefully
   and predictably coax Coq's type inference engine into triggering
   the execution of user-supplied algorithms during unification, and
   illustrates these patterns through several realistic examples drawn
   from Hoare Type Theory. The project also contains typeclass-based
   re-implementations for comparison.
-
-  [manual]: https://coq.inria.fr/distrib/current/refman/addendum/canonical-structures.html
 
 paper:
   doi: 10.1017/S0956796813000051

--- a/templates/examples/lemma-overloading/opam2
+++ b/templates/examples/lemma-overloading/opam2
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/coq-community/lemma-overloading"
+dev-repo: "https://github.com/coq-community/lemma-overloading.git"
+bug-reports: "https://github.com/coq-community/lemma-overloading/issues"
+license: "GPL-3.0-or-later"
+
+synopsis: "Libraries demonstrating design patterns for programming and proving with canonical structures in Coq"
+description: """
+This project contains Hoare Type Theory libraries which
+demonstrate a series of design patterns for programming
+with canonical structures that enable one to carefully
+and predictably coax Coq's type inference engine into triggering
+the execution of user-supplied algorithms during unification, and
+illustrates these patterns through several realistic examples drawn
+from Hoare Type Theory. The project also contains typeclass-based
+re-implementations for comparison.
+"""
+
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/LemmaOverloading"]
+flags: light-uninstall
+depends: [
+  "ocaml"
+  "coq" {(>= "8.8" & < "8.10~") | (= "dev")}
+  "coq-mathcomp-ssreflect" {(>= "1.7.0" & < "1.8~") | (= "dev")}
+]
+
+tags: [
+  "category:Computer Science/Data Types and Data Structures"
+  "keyword:canonical structures"
+  "keyword:proof automation"
+  "keyword:hoare type theory"
+  "keyword:lemma overloading"
+  "logpath:LemmaOverloading"
+]
+authors: [
+  "Georges Gonthier"
+  "Beta Ziliani"
+  "Aleksandar Nanevski"
+  "Derek Dreyer"
+]

--- a/templates/opam2.mustache
+++ b/templates/opam2.mustache
@@ -1,4 +1,4 @@
-opam-version: "1.2"
+opam-version: "2.0"
 maintainer: "{{& opam-file-maintainer }}{{^ opam-file-maintainer }}palmskog@gmail.com{{/ opam-file-maintainer }}"
 
 homepage: "https://github.com/{{ organization }}/{{ shortname }}"
@@ -6,10 +6,16 @@ dev-repo: "https://github.com/{{ organization }}/{{ shortname }}.git"
 bug-reports: "https://github.com/{{ organization }}/{{ shortname }}/issues"
 {{# license }}license: "{{ identifier }}"{{/ license }}
 
+synopsis: "{{& synopsis }}"
+description: """
+{{& description }}"""
+
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/{{ namespace }}"]
+flags: light-uninstall
 depends: [
+  "ocaml"
 {{# supported_coq_versions }}
   "coq" {{& opam }}
 {{/ supported_coq_versions }}


### PR DESCRIPTION
This is a (possibly-controversial?) PR where I both generalize some templates to also accommodate coq-contrib projects, and introduce an OPAM 2 template.

cc: @Zimmi48 @herbelin 