### PR TITLE
show email in opam when available, fix more escaping

### DIFF
--- a/templates/README.md.mustache
+++ b/templates/README.md.mustache
@@ -1,4 +1,4 @@
-# {{ fullname }}
+# {{& fullname }}
 
 [![Travis][travis-shield]][travis-link]
 [![Contributing][contributing-shield]][contributing-link]
@@ -41,16 +41,16 @@ More details about the project can be found in the paper
   - {{& name }} ([**@{{ nickname }}**](https://github.com/{{ nickname }}))
 {{/ maintainers }}
 {{# license }}
-- License: [{{ fullname }}]({{ file }}{{^ file }}LICENSE{{/ file }})
+- License: [{{& fullname }}]({{ file }}{{^ file }}LICENSE{{/ file }})
 {{/ license }}
 {{# supported_coq_versions }}
-- Compatible Coq versions: {{ text }}
+- Compatible Coq versions: {{& text }}
 {{/ supported_coq_versions }}
 {{# plugin }}
 - Compatible OCaml versions: all versions supported by Coq
 {{/ plugin }}
 - Additional dependencies:{{# dependencies }}
-  - {{ description }}
+  - {{& description }}
 {{/ dependencies }}{{^ dependencies }} none{{/ dependencies }}
 
 ## Building and installation instructions

--- a/templates/opam.mustache
+++ b/templates/opam.mustache
@@ -34,6 +34,6 @@ tags: [
 ]
 authors: [
 {{# authors }}
-  "{{& name }}"
+  "{{& name }}{{# email }} <{{& email }}>{{/ email }}"
 {{/ authors }}
 ]

--- a/templates/opam2.mustache
+++ b/templates/opam2.mustache
@@ -40,6 +40,6 @@ tags: [
 ]
 authors: [
 {{# authors }}
-  "{{& name }}"
+  "{{& name }}{{# email }} <{{& email }}>{{/ email }}"
 {{/ authors }}
 ]


### PR DESCRIPTION
We can store emails from legacy description files for authors in `email` entries in `meta.yml`:
```
authors:
- name: James R. Hacker
  initial: true
  email: jrh@example.com
```
These then get reflected in `opam` files using this template modification.