### PR TITLE
Update CI template examples to use the new coq-on-cachix repo.

### DIFF
--- a/templates/examples/aac-tactics/.travis.yml
+++ b/templates/examples/aac-tactics/.travis.yml
@@ -7,7 +7,7 @@ matrix:
   include:
 
   # Test supported versions of Coq
-  - env: COQ=https://github.com/coq/coq/tarball/master
+  - env: COQ=https://github.com/coq/coq-on-cachix/tarball/master
 
   # Test opam package
   - language: minimal

--- a/templates/examples/aac-tactics/meta.yml
+++ b/templates/examples/aac-tactics/meta.yml
@@ -45,7 +45,7 @@ supported_coq_versions:
   opam: '{= "dev"}'
 
 tested_coq_versions:
-- version_or_url: https://github.com/coq/coq/tarball/master
+- version_or_url: https://github.com/coq/coq-on-cachix/tarball/master
 
 tested_coq_opam_version: dev
 

--- a/templates/examples/lemma-overloading/.travis.yml
+++ b/templates/examples/lemma-overloading/.travis.yml
@@ -7,7 +7,7 @@ matrix:
   include:
 
   # Test supported versions of Coq
-  - env: COQ=https://github.com/coq/coq/tarball/master
+  - env: COQ=https://github.com/coq/coq-on-cachix/tarball/master
   - env: COQ=8.9
   - env: COQ=8.8
 

--- a/templates/examples/lemma-overloading/meta.yml
+++ b/templates/examples/lemma-overloading/meta.yml
@@ -48,7 +48,7 @@ supported_coq_versions:
   opam: '{(>= "8.8" & < "8.10~") | (= "dev")}'
 
 tested_coq_versions:
-- version_or_url: https://github.com/coq/coq/tarball/master
+- version_or_url: https://github.com/coq/coq-on-cachix/tarball/master
 - version_or_url: 8.9
 - version_or_url: 8.8
 


### PR DESCRIPTION
The coq-on-cachix repo lags a bit behind the main Coq repo but guarantees that it has already been built and uploaded to Cachix.
See also https://github.com/coq/coq/wiki/Nix.