### PR TITLE
Variable to make badges/maintainers optional in README

### DIFF
--- a/templates/README.md.mustache
+++ b/templates/README.md.mustache
@@ -1,19 +1,19 @@
 # {{& fullname }}
 
 [![Travis][travis-shield]][travis-link]
+{{# community }}
 [![Contributing][contributing-shield]][contributing-link]
 [![Code of Conduct][conduct-shield]][conduct-link]
 [![Gitter][gitter-shield]][gitter-link]
+{{/ community }}
 {{# paper }}
 [![DOI][doi-shield]][doi-link]
-
-[doi-shield]: https://zenodo.org/badge/DOI/{{ doi }}.svg
-[doi-link]: https://doi.org/{{ doi }}
 {{/ paper }}
 
 [travis-shield]: https://travis-ci.com/{{ organization }}/{{ shortname }}.svg?branch=master
 [travis-link]: https://travis-ci.com/{{ organization }}/{{ shortname }}/builds
 
+{{# community }}
 [contributing-shield]: https://img.shields.io/badge/contributions-welcome-%23f7931e.svg
 [contributing-link]: https://github.com/coq-community/manifesto/blob/master/CONTRIBUTING.md
 
@@ -22,6 +22,12 @@
 
 [gitter-shield]: https://img.shields.io/badge/chat-on%20gitter-%23c1272d.svg
 [gitter-link]: https://gitter.im/coq-community/Lobby
+{{/ community }}
+
+{{# paper }}
+[doi-shield]: https://zenodo.org/badge/DOI/{{ doi }}.svg
+[doi-link]: https://doi.org/{{ doi }}
+{{/ paper }}
 
 {{& description }}
 
@@ -36,10 +42,12 @@ More details about the project can be found in the paper
 {{# authors }}
   - {{& name }}{{# initial }} (initial){{/ initial }}
 {{/ authors }}
-- Maintainer(s):
+{{# community }}
+- Coq-community maintainer(s):
 {{# maintainers }}
   - {{& name }} ([**@{{ nickname }}**](https://github.com/{{ nickname }}))
 {{/ maintainers }}
+{{/ community }}
 {{# license }}
 - License: [{{& fullname }}]({{ file }}{{^ file }}LICENSE{{/ file }})
 {{/ license }}

--- a/templates/examples/aac-tactics/README.md
+++ b/templates/examples/aac-tactics/README.md
@@ -6,9 +6,6 @@
 [![Gitter][gitter-shield]][gitter-link]
 [![DOI][doi-shield]][doi-link]
 
-[doi-shield]: https://zenodo.org/badge/DOI/10.1007/978-3-642-25379-9_14.svg
-[doi-link]: https://doi.org/10.1007/978-3-642-25379-9_14
-
 [travis-shield]: https://travis-ci.com/coq-community/aac-tactics.svg?branch=master
 [travis-link]: https://travis-ci.com/coq-community/aac-tactics/builds
 
@@ -20,6 +17,9 @@
 
 [gitter-shield]: https://img.shields.io/badge/chat-on%20gitter-%23c1272d.svg
 [gitter-link]: https://gitter.im/coq-community/Lobby
+
+[doi-shield]: https://zenodo.org/badge/DOI/10.1007/978-3-642-25379-9_14.svg
+[doi-link]: https://doi.org/10.1007/978-3-642-25379-9_14
 
 This Coq plugin provides tactics for rewriting universally quantified
 equations, modulo associativity and commutativity of some operator.
@@ -38,7 +38,7 @@ More details about the project can be found in the paper
   - Thomas Braibant (initial)
   - Damien Pous (initial)
   - Fabian Kunze
-- Maintainer(s):
+- Coq-community maintainer(s):
   - Fabian Kunze ([**@fakusb**](https://github.com/fakusb))
   - Karl Palmskog ([**@palmskog**](https://github.com/palmskog))
 - License: [GNU Lesser General Public License v3.0 or later](LICENSE)

--- a/templates/examples/aac-tactics/meta.yml
+++ b/templates/examples/aac-tactics/meta.yml
@@ -2,8 +2,11 @@
 fullname: AAC tactics
 shortname: aac-tactics
 organization: coq-community
+community: true
 
-synopsis: This Coq plugin provides tactics for rewriting universally quantified equations, modulo associative (and possibly commutative) operators
+synopsis: >-
+  This Coq plugin provides tactics for rewriting universally quantified
+  equations, modulo associative (and possibly commutative) operators
 
 description: |
   This Coq plugin provides tactics for rewriting universally quantified

--- a/templates/examples/lemma-overloading/README.md
+++ b/templates/examples/lemma-overloading/README.md
@@ -6,9 +6,6 @@
 [![Gitter][gitter-shield]][gitter-link]
 [![DOI][doi-shield]][doi-link]
 
-[doi-shield]: https://zenodo.org/badge/DOI/10.1017/S0956796813000051.svg
-[doi-link]: https://doi.org/10.1017/S0956796813000051
-
 [travis-shield]: https://travis-ci.com/coq-community/lemma-overloading.svg?branch=master
 [travis-link]: https://travis-ci.com/coq-community/lemma-overloading/builds
 
@@ -20,6 +17,9 @@
 
 [gitter-shield]: https://img.shields.io/badge/chat-on%20gitter-%23c1272d.svg
 [gitter-link]: https://gitter.im/coq-community/Lobby
+
+[doi-shield]: https://zenodo.org/badge/DOI/10.1017/S0956796813000051.svg
+[doi-link]: https://doi.org/10.1017/S0956796813000051
 
 This project contains Hoare Type Theory libraries which
 demonstrate a series of design patterns for programming
@@ -41,7 +41,7 @@ More details about the project can be found in the paper
   - Beta Ziliani (initial)
   - Aleksandar Nanevski (initial)
   - Derek Dreyer (initial)
-- Maintainer(s):
+- Coq-community maintainer(s):
   - Anton Trunov ([**@anton-trunov**](https://github.com/anton-trunov))
   - Karl Palmskog ([**@palmskog**](https://github.com/palmskog))
 - License: [GNU General Public License v3.0 or later](LICENSE.md)

--- a/templates/examples/lemma-overloading/meta.yml
+++ b/templates/examples/lemma-overloading/meta.yml
@@ -2,8 +2,11 @@
 fullname: Lemma overloading
 shortname: lemma-overloading
 organization: coq-community
+community: true
 
-synopsis: Libraries demonstrating design patterns for programming and proving with canonical structures in Coq
+synopsis: >-
+  Libraries demonstrating design patterns for programming and proving
+  with canonical structures in Coq
 
 description: |
   This project contains Hoare Type Theory libraries which


### PR DESCRIPTION
While I agree with the criticism by @Zimmi48 in #44, I feel the burden of having separate README templates for coq-community and coq-contribs will be high. I was also hoping to use the template for other Coq projects.

Here is a compromise where a variable `community` can be used to add the community-specific parts. Here is what the adjusted README looks like on a coq-contrib project: https://github.com/palmskog/quicksort-complexity/tree/meta