### PR TITLE
use automatic uninstall in OPAM files

### DIFF
--- a/templates/coq.opam.mustache
+++ b/templates/coq.opam.mustache
@@ -12,8 +12,6 @@ description: """
 
 build: [make "-j%{jobs}%"]
 install: [make "install"]
-remove: ["rm" "-R" "%{lib}%/coq/user-contrib/{{ namespace }}"]
-flags: light-uninstall
 depends: [
   "ocaml"
 {{# supported_coq_versions }}

--- a/templates/examples/aac-tactics/coq-aac-tactics.opam
+++ b/templates/examples/aac-tactics/coq-aac-tactics.opam
@@ -18,8 +18,6 @@ provided with the plugin.
 
 build: [make "-j%{jobs}%"]
 install: [make "install"]
-remove: ["rm" "-R" "%{lib}%/coq/user-contrib/AAC_tactics"]
-flags: light-uninstall
 depends: [
   "ocaml"
   "coq" {= "dev"}

--- a/templates/examples/chapar/coq-chapar.opam
+++ b/templates/examples/chapar/coq-chapar.opam
@@ -16,8 +16,6 @@ of client programs.
 
 build: [make "-j%{jobs}%"]
 install: [make "install"]
-remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Chapar"]
-flags: light-uninstall
 depends: [
   "ocaml"
   "coq" {(>= "8.9" & < "8.10~") | (= "dev")}

--- a/templates/examples/lemma-overloading/coq-lemma-overloading.opam
+++ b/templates/examples/lemma-overloading/coq-lemma-overloading.opam
@@ -20,8 +20,6 @@ re-implementations for comparison.
 
 build: [make "-j%{jobs}%"]
 install: [make "install"]
-remove: ["rm" "-R" "%{lib}%/coq/user-contrib/LemmaOverloading"]
-flags: light-uninstall
 depends: [
   "ocaml"
   "coq" {(>= "8.8" & < "8.10~") | (= "dev")}


### PR DESCRIPTION
The Coq OPAM archive maintainers now require that there are no `remove` clauses in OPAM files, since OPAM 2 handles tracking of installed files. Here is an update to our template to reflect this.