### PR TITLE
add '-k path' option to opam in travis to avoid remote packages in CI

### DIFF
--- a/templates/.travis.yml.mustache
+++ b/templates/.travis.yml.mustache
@@ -12,7 +12,7 @@ opam: &OPAM
       export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
       set -ex  # -e = exit on failure; -x = trace for debug
       opam update -y
-      opam pin add ${CONTRIB_NAME} . -y --no-action
+      opam pin add ${CONTRIB_NAME} . -y -n -k path
       opam install ${CONTRIB_NAME} -y -j ${NJOBS} --deps-only
       opam config list
       opam repo list

--- a/templates/examples/aac-tactics/.travis.yml
+++ b/templates/examples/aac-tactics/.travis.yml
@@ -12,7 +12,7 @@ opam: &OPAM
       export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
       set -ex  # -e = exit on failure; -x = trace for debug
       opam update -y
-      opam pin add ${CONTRIB_NAME} . -y --no-action
+      opam pin add ${CONTRIB_NAME} . -y -n -k path
       opam install ${CONTRIB_NAME} -y -j ${NJOBS} --deps-only
       opam config list
       opam repo list

--- a/templates/examples/chapar/.travis.yml
+++ b/templates/examples/chapar/.travis.yml
@@ -12,7 +12,7 @@ opam: &OPAM
       export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
       set -ex  # -e = exit on failure; -x = trace for debug
       opam update -y
-      opam pin add ${CONTRIB_NAME} . -y --no-action
+      opam pin add ${CONTRIB_NAME} . -y -n -k path
       opam install ${CONTRIB_NAME} -y -j ${NJOBS} --deps-only
       opam config list
       opam repo list

--- a/templates/examples/lemma-overloading/.travis.yml
+++ b/templates/examples/lemma-overloading/.travis.yml
@@ -12,7 +12,7 @@ opam: &OPAM
       export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
       set -ex  # -e = exit on failure; -x = trace for debug
       opam update -y
-      opam pin add ${CONTRIB_NAME} . -y --no-action
+      opam pin add ${CONTRIB_NAME} . -y -n -k path
       opam install ${CONTRIB_NAME} -y -j ${NJOBS} --deps-only
       opam config list
       opam repo list


### PR DESCRIPTION
I've seen some weird behavior from unqualified `opam pin add [...] .`, i.e., when pinning the current directory. This change ensures that local directories are always used in Travis.