### PR TITLE
Move badge from Gitter to Zulip.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
-[![Contributing](https://img.shields.io/badge/contributions-welcome-%23f7931e.svg)](https://github.com/coq-community/manifesto/blob/master/CONTRIBUTING.md)
-[![Code of Conduct](https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-%23f15a24.svg)](https://github.com/coq-community/manifesto/blob/master/CODE_OF_CONDUCT.md)
-[![Gitter](https://img.shields.io/badge/chat-on%20gitter-%23c1272d.svg)](https://gitter.im/coq-community/Lobby)
+[![Contributing][contributing-shield]][contributing-link]
+[![Code of Conduct][conduct-shield]][conduct-link]
+[![Zulip][zulip-shield]][zulip-link]
+
+[contributing-shield]: https://img.shields.io/badge/contributions-welcome-%23f7931e.svg
+[contributing-link]: https://github.com/coq-community/manifesto/blob/master/CONTRIBUTING.md
+
+[conduct-shield]: https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-%23f15a24.svg
+[conduct-link]: https://github.com/coq-community/manifesto/blob/master/CODE_OF_CONDUCT.md
+
+[zulip-shield]: https://img.shields.io/badge/chat-on%20zulip-%23c1272d.svg
+[zulip-link]: https://coq.zulipchat.com/#narrow/stream/237663-coq-community-devs.20.26.20users
 
 # [![coq-community](logo.svg)](https://github.com/coq-community) #
 


### PR DESCRIPTION
Step toward coq-community/templates#40.