### PR TITLE
Refine code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,7 +6,7 @@ upheld by all participants in any coq-community forum (GitHub, Zulip, etc.).
 
 **Be respectful and inclusive.** Please do not use overtly sexual language or
 imagery, and do not attack anyone based on any aspect of personal identity,
-including gender, sexuality, religion, ethnicity, race, employment status,
+including gender, sexuality, political views, religion, ethnicity, race, employment status,
 age or ability. Keep in mind that what you write in public forums is read by
 many people who don’t know you personally, so please refrain from making
 prejudiced, sexual or political jokes and comments – even ones that you might

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,7 +2,7 @@
 
 coq-community members are committed to maintaining a welcoming, civil and
 constructive environment. We expect the following standards to be observed and
-upheld by all participants in any community forum (GitHub, Zulip, etc.).
+upheld by all participants in any coq-community forum (GitHub, Zulip, etc.).
 
 **Be respectful and inclusive.** Please do not use overtly sexual language or
 imagery, and do not attack anyone based on any aspect of personal identity,


### PR DESCRIPTION
I want to ensure that coq-community members are not attacked or reported for code-of-conduct violations based on (possibly politically-charged) statements or behavior that occur **outside** of coq-community, e.g., on Twitter, in personal blogs, and in issues in other GitHub organizations. 

Here are two refinements of the code of conduct which I believe are conducive to this goal.

Note that the explicit mention of political views as an aspect of personal identity also exist in the Julia community standards, which the current code is based on.