### PR TITLE
restrict licenses to OSI approved or FSF free software, encourage OSI-FSF intersection

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,10 @@ collaboratively improved. Please contribute!*
 Fill in the requested information. In particular here are some requirements to
 move a project to coq-community:
 
-- The project must have an open source license (non-commercial / academic
-  licenses are not acceptable).
+- The project must have a license that is either
+  [approved as an open source license by the OSI][osi-approved-license]
+  or [considered a free software license by the FSF][fsf-free-software-license]
+  (non-commercial / academic licenses are not acceptable).
 - The main authors of the package must either consent to this move or be
   completely unresponsive. Therefore, once a project is proposed, we will
   open an issue at the original project URL (or send an e-mail when this
@@ -70,7 +72,13 @@ Opening a pull request on this meta-project implies that you accept to put
 your contribution under the CC0 license: see [`LICENSE.md`](LICENSE.md).
 
 [move_project]: https://github.com/coq-community/manifesto/issues/new?labels=move-project&template=1-move-a-project.md&title=Proposal+to+move+project+X+to+coq-community
+
+[osi-approved-license]: https://opensource.org/licenses/alphabetical
+
+[fsf-free-software-license]: https://www.gnu.org/licenses/license-list.html
+
 [change_maintainer]: https://github.com/coq-community/manifesto/issues/new?labels=change-maintainer&template=2-change-maintainer.md&title=Change+maintainer+of+project+X
+
 [meta]: https://github.com/coq-community/manifesto/issues/new?labels=meta&template=3-meta.md
 
 [templates]: https://github.com/coq-community/templates

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,8 @@ Fill in the requested information. In particular here are some requirements to
 move a project to coq-community:
 
 - The project must have a license that is either
-  [approved as an open source license by the OSI][osi-approved-license]
-  or [considered a free software license by the FSF][fsf-free-software-license]
+  [approved as an open source license by OSI][osi-approved-license]
+  or [considered a free software license by FSF][fsf-free-software-license]
   (non-commercial / academic licenses are not acceptable).
 - The main authors of the package must either consent to this move or be
   completely unresponsive. Therefore, once a project is proposed, we will

--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ editorial work.
 
   The only strict requirement is to use a license that is either
 
-  - [approved as an open source license by the OSI][osi-approved-license], or
-  - [considered a free software license by the FSF][fsf-free-software-license].
+  - [approved as an open source license by OSI][osi-approved-license], or
+  - [considered a free software license by FSF][fsf-free-software-license].
 
   If you create a new project or propose to transfer a project
   of which you are the sole copyright owner, we strongly encourage you

--- a/README.md
+++ b/README.md
@@ -150,9 +150,8 @@ editorial work.
 - **What license to use for a coq-community project?**
 
   The only strict requirement is to use a license that is either
-
-  - [approved as an open source license by OSI][osi-approved-license], or
-  - [considered a free software license by FSF][fsf-free-software-license].
+  [approved as an open source license by OSI][osi-approved-license]
+  or [considered a free software license by FSF][fsf-free-software-license].
 
   If you create a new project or propose to transfer a project
   of which you are the sole copyright owner, we strongly encourage you
@@ -171,7 +170,8 @@ editorial work.
     because it is technically simpler to understand and abide by.
 
   If neither of these two licenses can be used, we encourage using
-  another open source license approved by the OSI.
+  another license that is both approved as an open source license
+  by OSI and considered a free software license by FSF.
 
 ### Process / organizational aspects ###
 

--- a/README.md
+++ b/README.md
@@ -147,18 +147,20 @@ editorial work.
   patches from Coq developers when they introduce a breaking change (this is
   particularly recommended for plugins).
 
-- **What license to choose for a coq-community project?**
+- **What license to use for a coq-community project?**
 
-  The only strict requirement is to use an [open source
-  license](https://opensource.org/licenses).  However, if you create a
-  new project or propose to transfer a project of which you are the
-  sole copyright owner, we strongly encourage you to (re)license your
-  project under one of the following two licenses:
+  The only strict requirement is to use a license that is either
+
+  - [approved as an open source license by the OSI][osi-approved-license], or
+  - [considered a free software license by the FSF][fsf-free-software-license].
+
+  If you create a new project or propose to transfer a project
+  of which you are the sole copyright owner, we strongly encourage you
+  to (re)license your project under one of the following two licenses:
 
   - [MIT license](https://choosealicense.com/licenses/mit/): a very
     permissive and popular open source license.  This is the best
     choice if you want to maximize the reusability of your project.
-
   - [MPL-2.0 license](https://choosealicense.com/licenses/mpl-2.0/): a
     weak [copyleft](https://en.wikipedia.org/wiki/Copyleft) license.
     You can use this license if you want to restrict the license under
@@ -167,6 +169,9 @@ editorial work.
     license should be preferred over the (historically more prevalent)
     [LGPL-2.1 license](https://choosealicense.com/licenses/lgpl-2.1/)
     because it is technically simpler to understand and abide by.
+
+  If neither of these two licenses can be used, we encourage using
+  another open source license approved by the OSI.
 
 ### Process / organizational aspects ###
 
@@ -224,6 +229,10 @@ editorial work.
 
 Is anything still unclear? Please [open an issue][meta] or
 [chat on Zulip][zulip-link] to ask a question.
+
+[osi-approved-license]: https://opensource.org/licenses/alphabetical
+
+[fsf-free-software-license]: https://www.gnu.org/licenses/license-list.html
 
 [archive]: https://github.com/coq-community?utf8=%E2%9C%93&q=&type=archived
 

--- a/README.md
+++ b/README.md
@@ -152,8 +152,7 @@ editorial work.
   The only strict requirement is to use a license that is either
   [approved as an open source license by OSI][osi-approved-license]
   or [considered a free software license by FSF][fsf-free-software-license].
-
-  If you create a new project or propose to transfer a project
+  However, if you create a new project or propose to transfer a project
   of which you are the sole copyright owner, we strongly encourage you
   to (re)license your project under one of the following two licenses:
 


### PR DESCRIPTION
We want to explicitly allow non-OSI free software licenses such as CECILL-B and CECILL-C, while encouraging MIT/MPL-2.0 and preferring OSI over non-OSI. Based on [this discussion in the Coq Zulip](https://coq.gitlab.io/zulip-archive/stream/237663-coq-community-devs-&-users/topic/open.20source.20vs.2E.20OSI.html).

I change from "choose" to "use", since these are requirements that restrict choice rather than mere recommendations on top of free choice.